### PR TITLE
fix: nuxt typecheck error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-color-picker",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-color-picker",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.14.1592"

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "nuxi dev",
     "build": "nuxi build",
-    "generate": "nuxi generate"
+    "generate": "nuxi generate",
+    "typecheck": "nuxi typecheck"
   },
   "dependencies": {
     "@nuxthub/core": "^0.8.8",

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,6 +9,12 @@ export default defineNuxtModule({
 
     _nuxt.options.css.push(resolver.resolve('runtime', 'assets', 'main.css'));
 
+    _nuxt.hook('prepare:types', ({ references }) => {
+      references.push({
+        path: resolver.resolve('./runtime/types/eyedropper.d.ts')
+      });
+    });
+
     addPlugin({
       src: resolver.resolve('./runtime/plugin'),
       mode: 'client'

--- a/src/runtime/components/Hue.vue
+++ b/src/runtime/components/Hue.vue
@@ -34,7 +34,7 @@ function bgGenerator(ctx: CanvasRenderingContext2D, width: number, height: numbe
 }
 function selectGenerator(ctx: CanvasRenderingContext2D, width: number, height: number, { y }: ModuleStylesY) {
   const imgData = ctx.getImageData(0, Math.min(y, height - 1), 1, 1);
-  const [r, g, b] = imgData.data;
+  const [r, g, b] = imgData.data as unknown as [number, number, number];
   return rgb2rgbHue({ r, g, b });
 }
 function sliderXYGenerator(width: number, height: number): ModuleStylesY {

--- a/src/runtime/components/Saturation.vue
+++ b/src/runtime/components/Saturation.vue
@@ -38,7 +38,7 @@ function bgGenerator(ctx: CanvasRenderingContext2D, width: number, height: numbe
 }
 function selectGenerator(ctx: CanvasRenderingContext2D, width: number, height: number, { x, y }: ModuleStylesXY) {
   const imgData = ctx.getImageData(Math.min(x + 5, width - 1), Math.min(y + 5, height - 1), 1, 1);
-  const [r, g, b] = imgData.data;
+  const [r, g, b] = imgData.data as unknown as [number, number, number];
   return { r, g, b };
 }
 function sliderXYGenerator(width: number, height: number): ModuleStylesXY {


### PR DESCRIPTION
Hello, I'm using this library, but when I run `nuxt typecheck`, the following type errors occur:

- `EyeDropper` cannot be found.
- `const [r, g, b] = imgData.data` may result in `r`, `g`, or `b` being `undefined`.

So I have made fixes to resolve these type errors.